### PR TITLE
update instructions for GCE VM and virtual env setup

### DIFF
--- a/src/colab/Initialize_SKAI_XManager_Colab_Kernel.ipynb
+++ b/src/colab/Initialize_SKAI_XManager_Colab_Kernel.ipynb
@@ -1,6 +1,7 @@
 {
   "cells": [
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "ahFVM6s5B14O"
@@ -14,6 +15,20 @@
         "2. Connect to the custom kernel you want to initialize.\n",
         "3. Change settings as appropriate.\n",
         "4. Run all code cells.\n"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Connecting to GCE VM\n",
+        "To run this notebook, it is recommended that user connects to a Google Cloud Engine (GCE) virtual machine (VM) for Colab as their runtime. \n",
+        "To do this, \n",
+        "  1. Please click the downward arrow next to \"Connect\" at the top left of this notebook. \n",
+        "  2. Select \"Connect to a custom GCE VM\" from the drop-down and enter the *Project*, *Zone* and *Instance* information.\n",
+        "\n",
+        "If user needs to create a new GCE VM, please follow the [instructions here](https://research.google.com/colaboratory/marketplace.html)\n"
       ]
     },
     {
@@ -45,6 +60,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "KzSkXvGX6IAz"
@@ -99,6 +115,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "Do9KUQWkC5hd"
@@ -125,6 +142,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "6szMvm-1CNFp"
@@ -150,6 +168,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "6py-IvQxCV5y"

--- a/src/colab/Run_SKAI_XManager_Colab_Pipeline.ipynb
+++ b/src/colab/Run_SKAI_XManager_Colab_Pipeline.ipynb
@@ -1,6 +1,7 @@
 {
   "cells": [
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "qxZ4Nbz5x6Bw"
@@ -15,6 +16,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "A1IfnanckHeo"
@@ -24,6 +26,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "zAc_6ag50kyU"
@@ -56,12 +59,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "cellView": "form",
         "id": "tm86-tWoSZYJ"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "UsageError: Line magic function `%shell` not found.\n"
+          ]
+        }
+      ],
       "source": [
         "import os\n",
         "import datetime\n",
@@ -96,12 +107,27 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {
         "cellView": "form",
         "id": "9vSAGvIiTMhq"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "--config=src/skai/model/configs/skai_two_tower_config.py --config.data.tfds_dataset_name=skai_dataset --config.data.tfds_data_dir=gs://skai-data/hurricane_ian --config.output_dir=gs://skai-data/experiments/skai_train_vizier --config.training.num_epochs=10 --accelerator=V100 --experiment_name=skai_train_vizier\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "UsageError: Line magic function `%shell` not found.\n"
+          ]
+        }
+      ],
       "source": [
         "#@title Run XManager Train Job (with Vizier Hyperparameter Tuning) on Vertex AI\n",
         "\n",
@@ -136,6 +162,7 @@
         "export GOOGLE_CLOUD_BUCKET_NAME={GOOGLE_CLOUD_BUCKET_NAME}\n",
         "\n",
         "cd {SKAI_CODE_DIR}\n",
+        "source {pathsys_actenv}\n",
         "xmanager launch src/skai/model/xm_launch_single_model_vertex.py -- \\\n",
         "--xm_wrap_late_bindings \\\n",
         "--xm_upgrade_db=True \\\n",
@@ -148,6 +175,13 @@
         "\n",
         "%shell bash script.sh"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
     }
   ],
   "metadata": {
@@ -162,7 +196,16 @@
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.0"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
1. This adds instructions on how to setup a Google Compute Engine virtual machine to run experiments.

2. Python environment has to be activated in bash script. This PR resolves this issue